### PR TITLE
Add empirical discrete distribution

### DIFF
--- a/src/EmpiricalDistributions.jl
+++ b/src/EmpiricalDistributions.jl
@@ -17,5 +17,6 @@ using StatsBase
 include("utils.jl")
 include("uv_binned_dist.jl")
 include("mv_binned_dist.jl")
+include("uv_discrete_dist.jl")
 
 end # module

--- a/src/uv_discrete_dist.jl
+++ b/src/uv_discrete_dist.jl
@@ -14,3 +14,6 @@ function UvDiscreteDist(data::Vector{T} where T <: Real)::Distribution{Univariat
     pmf_data = vcat(cdf_data[1],diff(cdf_data)) #create pmf from the cdf
     DiscreteNonParametric(data_clean,pmf_data) #define distribution
 end
+
+#Define mean for truncated DiscreteNonParametric
+StatsBase.mean(f::Distribution{Univariate, Discrete}) = Distributions.dot(pdf.(Ref(f), Distributions.support(f)),Distributions.support(f))

--- a/src/uv_discrete_dist.jl
+++ b/src/uv_discrete_dist.jl
@@ -1,0 +1,16 @@
+export UvDiscreteDist
+
+"""
+    UvDiscreteDist(data::Vector{T} where T <: Real)::Distribution{Univariate,Discrete}
+
+Create a discrete empirical distribution based on `data`.
+"""
+function UvDiscreteDist(data::Vector{T} where T <: Real)::Distribution{Univariate,Discrete}
+    data = float.(data) #convert any int to float (to allow for integration if desired)
+    sort!(data) #sort the observations
+    empirical_cdf = ecdf(data) #create empirical cdf
+    data_clean = unique(data) #remove duplicates to avoid allunique error
+    cdf_data = empirical_cdf.(data_clean) #apply ecdf to data
+    pmf_data = vcat(cdf_data[1],diff(cdf_data)) #create pmf from the cdf
+    DiscreteNonParametric(data_clean,pmf_data) #define distribution
+end


### PR DESCRIPTION
I have added capabilities for creating an empirical discrete distribution directly from data (without fitting a Histogram). This is relevant for discrete data sets. See the example below, where fitting a continuous distribution using a histogram results in an erroneous pdf for a system where there is a 50% probability of getting a 1 and 50% probability of getting a 9:

```julia
julia> data = [1,9]
2-element Vector{Int64}:
 1
 9

julia> f = UvDiscreteDist([1,9])
DiscreteNonParametric{Float64, Float64, Vector{Float64}, Vector{Float64}}(support=[1.0, 9.0], p=[0.5, 0.5])                 r{Float64}}(support=

julia> g = UvBinnedDist(fit(Histogram,data))
UvBinnedDist{Float64, Float64, Vector{Float64}, Vector{Float64}}(                                                           }}(
_edge: [0.0, 5.0, 10.0]
_edge_cdf: [0.0, 0.5, 1.0]
_bin_pdf: [0.1, 0.1]
_bin_probmass: [0.5, 0.5]
_closed_left: true
_mean: 5.0
_mode: 2.5
_var: 6.25
)


julia> pdf(f,1)
0.5

julia> pdf(g,1)
0.1
```